### PR TITLE
avoid trying to make a float a char

### DIFF
--- a/color.lua
+++ b/color.lua
@@ -10,10 +10,10 @@ local M = {
 }
 
 local function hex_to_rgb(hex_color)
-        return {r = hex_color/(2^16) % 0x100,
-                g = hex_color/(2^8) % 0x100,
-                b = hex_color % 0x100
-                }
+    return {r = math.floor(hex_color/(2^16) % 0x100),
+            g = math.floor(hex_color/(2^8) % 0x100),
+            b = math.floor(hex_color % 0x100)
+    }
 end
 
 function M.hex(hex_color)


### PR DESCRIPTION
As lua operates with floating point numbers, the calculations in the
hex_to_char function can end up being floats, which can't be converted
to chars, which ends up throwing an error:

lua: color.lua:21: bad argument #2 to 'char' (number has no integer representation)

Fix that by doing math.floor on the numbers, so they are definitely
convertible to chars.