### PR TITLE
print color name if the color is not found

### DIFF
--- a/color.lua
+++ b/color.lua
@@ -19,9 +19,12 @@ end
 -- The color can be specified either by name, or by its hex value
 function M.hex(color)
     if type(color) == "string" then
-        color = M.colors[color]
+        local color_name = color
+        color = M.colors[color_name]
         if color == nil then
-            error("Color doesn't exist.  Feel free to add it and send a PR")
+	   error(string.format(
+		    "Color %q doesn't exist.  Feel free to add it and send a PR",
+		    color_name))
         end
     end
     local c = hex_to_rgb(color)


### PR DESCRIPTION
When a color is not found, it can be helpful to print the name of the
color that is not found to aid debugging.  E.g. when chaining things
together as in color.hex("red"):rep(5) .. color.hex("blue"):rep(5), it
can get tedious to search what was misspelled.